### PR TITLE
refactor: improve openapi naming

### DIFF
--- a/internal/server/v1/checklist/checklist_controller_impl.go
+++ b/internal/server/v1/checklist/checklist_controller_impl.go
@@ -14,52 +14,59 @@ type checklistController struct {
 	mapper  IChecklistDtoMapper
 }
 
-func (controller *checklistController) DeleteChecklistById(_ context.Context, request DeleteChecklistByIdRequestObject) (DeleteChecklistByIdResponseObject, error) {
+func (controller *checklistController) DeleteChecklist(_ context.Context, request DeleteChecklistRequestObject) (DeleteChecklistResponseObject, error) {
 	if err := controller.service.DeleteChecklistById(request.ChecklistId); err == nil {
-		return DeleteChecklistById204JSONResponse{}, nil
+		return DeleteChecklist204JSONResponse{}, nil
 	} else if err.ResponseCode() == http.StatusNotFound {
-		return DeleteChecklistById404JSONResponse{
+		return DeleteChecklist404JSONResponse{
+			Code:    http.StatusNotFound,
 			Message: err.Error(),
 		}, nil
 	} else {
-		return DeleteChecklistById500JSONResponse{
+		return DeleteChecklist500JSONResponse{
+			Code:    http.StatusInternalServerError,
 			Message: err.Error(),
 		}, nil
 	}
 }
 
-func (controller *checklistController) UpdateChecklistById(_ context.Context, request UpdateChecklistByIdRequestObject) (UpdateChecklistByIdResponseObject, error) {
+func (controller *checklistController) UpdateChecklist(_ context.Context, request UpdateChecklistRequestObject) (UpdateChecklistResponseObject, error) {
 	domainObject := controller.mapper.ToDomain(*request.Body)
 	domainObject.Id = request.ChecklistId
 	if checklist, err := controller.service.UpdateChecklist(domainObject); err == nil {
 		dto := controller.mapper.ToDTO(checklist)
-		return UpdateChecklistById200JSONResponse(dto), nil
+		return UpdateChecklist200JSONResponse(dto), nil
 	} else if err.ResponseCode() == http.StatusBadRequest {
-		return UpdateChecklistById400JSONResponse{
+		return UpdateChecklist400JSONResponse{
+			Code:    http.StatusBadRequest,
 			Message: err.Error(),
 		}, nil
 	} else if err.ResponseCode() == http.StatusNotFound {
-		return UpdateChecklistById404JSONResponse{
+		return UpdateChecklist404JSONResponse{
+			Code:    http.StatusNotFound,
 			Message: err.Error(),
 		}, nil
 	} else {
-		return UpdateChecklistById500JSONResponse{
+		return UpdateChecklist500JSONResponse{
+			Code:    http.StatusInternalServerError,
 			Message: err.Error(),
 		}, nil
 	}
 }
 
-func (controller *checklistController) GetAllChecklists(_ context.Context, _ GetAllChecklistsRequestObject) (GetAllChecklistsResponseObject, error) {
+func (controller *checklistController) ListChecklists(_ context.Context, _ ListChecklistsRequestObject) (ListChecklistsResponseObject, error) {
 
 	if checklists, err := controller.service.FindAllChecklists(); err == nil {
 		dto := controller.mapper.ToDtoArray(checklists)
-		return GetAllChecklists200JSONResponse(dto), nil
+		return ListChecklists200JSONResponse(dto), nil
 	} else if err.ResponseCode() == http.StatusBadRequest {
-		return GetAllChecklists400JSONResponse{
+		return ListChecklists400JSONResponse{
+			Code:    http.StatusBadRequest,
 			Message: err.Error(),
 		}, nil
 	} else {
-		return GetAllChecklists500JSONResponse{
+		return ListChecklists500JSONResponse{
+			Code:    http.StatusInternalServerError,
 			Message: err.Error(),
 		}, nil
 	}
@@ -72,29 +79,34 @@ func (controller *checklistController) CreateChecklist(_ context.Context, reques
 		return CreateChecklist201JSONResponse(dto), nil
 	} else if err.ResponseCode() == http.StatusBadRequest {
 		return CreateChecklist400JSONResponse{
+			Code:    http.StatusBadRequest,
 			Message: err.Error(),
 		}, nil
 	} else {
 		return CreateChecklist500JSONResponse{
+			Code:    http.StatusInternalServerError,
 			Message: err.Error(),
 		}, nil
 	}
 }
 
-func (controller *checklistController) GetChecklistById(_ context.Context, request GetChecklistByIdRequestObject) (GetChecklistByIdResponseObject, error) {
+func (controller *checklistController) GetChecklist(_ context.Context, request GetChecklistRequestObject) (GetChecklistResponseObject, error) {
 	if checklist, err := controller.service.FindChecklistById(request.ChecklistId); err == nil && checklist != nil {
 		dto := controller.mapper.ToDTO(*checklist)
-		return GetChecklistById200JSONResponse(dto), nil
+		return GetChecklist200JSONResponse(dto), nil
 	} else if err == nil && checklist == nil {
-		return GetChecklistById404JSONResponse{
+		return GetChecklist404JSONResponse{
+			Code:    http.StatusNotFound,
 			Message: "Checklist not found",
 		}, nil
 	} else if err.ResponseCode() == http.StatusBadRequest {
-		return GetChecklistById400JSONResponse{
+		return GetChecklist400JSONResponse{
+			Code:    http.StatusBadRequest,
 			Message: err.Error(),
 		}, nil
 	} else {
-		return GetChecklistById500JSONResponse{
+		return GetChecklist500JSONResponse{
+			Code:    http.StatusInternalServerError,
 			Message: err.Error(),
 		}, nil
 	}

--- a/internal/server/v1/checklist/server.gen.go
+++ b/internal/server/v1/checklist/server.gen.go
@@ -37,42 +37,40 @@ type ChecklistResponse struct {
 	Name  string                   `json:"name"`
 }
 
-// ChecklistUpdateAndCreateRequest defines model for ChecklistUpdateAndCreateRequest.
-type ChecklistUpdateAndCreateRequest struct {
+// CreateChecklistRequest defines model for CreateChecklistRequest.
+type CreateChecklistRequest struct {
 	Name string `json:"name"`
 }
 
-// CreateChecklistRequest defines model for CreateChecklistRequest.
-type CreateChecklistRequest = ChecklistUpdateAndCreateRequest
-
 // Error defines model for Error.
 type Error struct {
+	Code    int32  `json:"code"`
 	Message string `json:"message"`
 }
 
 // CreateChecklistJSONRequestBody defines body for CreateChecklist for application/json ContentType.
 type CreateChecklistJSONRequestBody = CreateChecklistRequest
 
-// UpdateChecklistByIdJSONRequestBody defines body for UpdateChecklistById for application/json ContentType.
-type UpdateChecklistByIdJSONRequestBody = CreateChecklistRequest
+// UpdateChecklistJSONRequestBody defines body for UpdateChecklist for application/json ContentType.
+type UpdateChecklistJSONRequestBody = CreateChecklistRequest
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
-	// Get all checklists
+	// List all checklists
 	// (GET /api/v1/checklists)
-	GetAllChecklists(c *gin.Context)
+	ListChecklists(c *gin.Context)
 	// Create a new checklist
 	// (POST /api/v1/checklists)
 	CreateChecklist(c *gin.Context)
-	// Delete checklist by ID
+	// Delete a checklist
 	// (DELETE /api/v1/checklists/{checklistId})
-	DeleteChecklistById(c *gin.Context, checklistId uint)
-	// Get checklist by ID
+	DeleteChecklist(c *gin.Context, checklistId uint)
+	// Get a checklist
 	// (GET /api/v1/checklists/{checklistId})
-	GetChecklistById(c *gin.Context, checklistId uint)
-	// Update checklist by ID
+	GetChecklist(c *gin.Context, checklistId uint)
+	// Update a checklist
 	// (PUT /api/v1/checklists/{checklistId})
-	UpdateChecklistById(c *gin.Context, checklistId uint)
+	UpdateChecklist(c *gin.Context, checklistId uint)
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -84,8 +82,8 @@ type ServerInterfaceWrapper struct {
 
 type MiddlewareFunc func(c *gin.Context)
 
-// GetAllChecklists operation middleware
-func (siw *ServerInterfaceWrapper) GetAllChecklists(c *gin.Context) {
+// ListChecklists operation middleware
+func (siw *ServerInterfaceWrapper) ListChecklists(c *gin.Context) {
 
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
@@ -94,7 +92,7 @@ func (siw *ServerInterfaceWrapper) GetAllChecklists(c *gin.Context) {
 		}
 	}
 
-	siw.Handler.GetAllChecklists(c)
+	siw.Handler.ListChecklists(c)
 }
 
 // CreateChecklist operation middleware
@@ -110,8 +108,8 @@ func (siw *ServerInterfaceWrapper) CreateChecklist(c *gin.Context) {
 	siw.Handler.CreateChecklist(c)
 }
 
-// DeleteChecklistById operation middleware
-func (siw *ServerInterfaceWrapper) DeleteChecklistById(c *gin.Context) {
+// DeleteChecklist operation middleware
+func (siw *ServerInterfaceWrapper) DeleteChecklist(c *gin.Context) {
 
 	var err error
 
@@ -131,11 +129,11 @@ func (siw *ServerInterfaceWrapper) DeleteChecklistById(c *gin.Context) {
 		}
 	}
 
-	siw.Handler.DeleteChecklistById(c, checklistId)
+	siw.Handler.DeleteChecklist(c, checklistId)
 }
 
-// GetChecklistById operation middleware
-func (siw *ServerInterfaceWrapper) GetChecklistById(c *gin.Context) {
+// GetChecklist operation middleware
+func (siw *ServerInterfaceWrapper) GetChecklist(c *gin.Context) {
 
 	var err error
 
@@ -155,11 +153,11 @@ func (siw *ServerInterfaceWrapper) GetChecklistById(c *gin.Context) {
 		}
 	}
 
-	siw.Handler.GetChecklistById(c, checklistId)
+	siw.Handler.GetChecklist(c, checklistId)
 }
 
-// UpdateChecklistById operation middleware
-func (siw *ServerInterfaceWrapper) UpdateChecklistById(c *gin.Context) {
+// UpdateChecklist operation middleware
+func (siw *ServerInterfaceWrapper) UpdateChecklist(c *gin.Context) {
 
 	var err error
 
@@ -179,7 +177,7 @@ func (siw *ServerInterfaceWrapper) UpdateChecklistById(c *gin.Context) {
 		}
 	}
 
-	siw.Handler.UpdateChecklistById(c, checklistId)
+	siw.Handler.UpdateChecklist(c, checklistId)
 }
 
 // GinServerOptions provides options for the Gin server.
@@ -209,41 +207,41 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 		ErrorHandler:       errorHandler,
 	}
 
-	router.GET(options.BaseURL+"/api/v1/checklists", wrapper.GetAllChecklists)
+	router.GET(options.BaseURL+"/api/v1/checklists", wrapper.ListChecklists)
 	router.POST(options.BaseURL+"/api/v1/checklists", wrapper.CreateChecklist)
-	router.DELETE(options.BaseURL+"/api/v1/checklists/:checklistId", wrapper.DeleteChecklistById)
-	router.GET(options.BaseURL+"/api/v1/checklists/:checklistId", wrapper.GetChecklistById)
-	router.PUT(options.BaseURL+"/api/v1/checklists/:checklistId", wrapper.UpdateChecklistById)
+	router.DELETE(options.BaseURL+"/api/v1/checklists/:checklistId", wrapper.DeleteChecklist)
+	router.GET(options.BaseURL+"/api/v1/checklists/:checklistId", wrapper.GetChecklist)
+	router.PUT(options.BaseURL+"/api/v1/checklists/:checklistId", wrapper.UpdateChecklist)
 }
 
-type GetAllChecklistsRequestObject struct {
+type ListChecklistsRequestObject struct {
 }
 
-type GetAllChecklistsResponseObject interface {
-	VisitGetAllChecklistsResponse(w http.ResponseWriter) error
+type ListChecklistsResponseObject interface {
+	VisitListChecklistsResponse(w http.ResponseWriter) error
 }
 
-type GetAllChecklists200JSONResponse []ChecklistResponse
+type ListChecklists200JSONResponse []ChecklistResponse
 
-func (response GetAllChecklists200JSONResponse) VisitGetAllChecklistsResponse(w http.ResponseWriter) error {
+func (response ListChecklists200JSONResponse) VisitListChecklistsResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetAllChecklists400JSONResponse Error
+type ListChecklists400JSONResponse Error
 
-func (response GetAllChecklists400JSONResponse) VisitGetAllChecklistsResponse(w http.ResponseWriter) error {
+func (response ListChecklists400JSONResponse) VisitListChecklistsResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(400)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetAllChecklists500JSONResponse Error
+type ListChecklists500JSONResponse Error
 
-func (response GetAllChecklists500JSONResponse) VisitGetAllChecklistsResponse(w http.ResponseWriter) error {
+func (response ListChecklists500JSONResponse) VisitListChecklistsResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
@@ -285,124 +283,124 @@ func (response CreateChecklist500JSONResponse) VisitCreateChecklistResponse(w ht
 	return json.NewEncoder(w).Encode(response)
 }
 
-type DeleteChecklistByIdRequestObject struct {
+type DeleteChecklistRequestObject struct {
 	ChecklistId uint `json:"checklistId"`
 }
 
-type DeleteChecklistByIdResponseObject interface {
-	VisitDeleteChecklistByIdResponse(w http.ResponseWriter) error
+type DeleteChecklistResponseObject interface {
+	VisitDeleteChecklistResponse(w http.ResponseWriter) error
 }
 
-type DeleteChecklistById204JSONResponse ChecklistResponse
+type DeleteChecklist204JSONResponse ChecklistResponse
 
-func (response DeleteChecklistById204JSONResponse) VisitDeleteChecklistByIdResponse(w http.ResponseWriter) error {
+func (response DeleteChecklist204JSONResponse) VisitDeleteChecklistResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(204)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type DeleteChecklistById404JSONResponse Error
+type DeleteChecklist404JSONResponse Error
 
-func (response DeleteChecklistById404JSONResponse) VisitDeleteChecklistByIdResponse(w http.ResponseWriter) error {
+func (response DeleteChecklist404JSONResponse) VisitDeleteChecklistResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(404)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type DeleteChecklistById500JSONResponse Error
+type DeleteChecklist500JSONResponse Error
 
-func (response DeleteChecklistById500JSONResponse) VisitDeleteChecklistByIdResponse(w http.ResponseWriter) error {
+func (response DeleteChecklist500JSONResponse) VisitDeleteChecklistResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetChecklistByIdRequestObject struct {
+type GetChecklistRequestObject struct {
 	ChecklistId uint `json:"checklistId"`
 }
 
-type GetChecklistByIdResponseObject interface {
-	VisitGetChecklistByIdResponse(w http.ResponseWriter) error
+type GetChecklistResponseObject interface {
+	VisitGetChecklistResponse(w http.ResponseWriter) error
 }
 
-type GetChecklistById200JSONResponse ChecklistResponse
+type GetChecklist200JSONResponse ChecklistResponse
 
-func (response GetChecklistById200JSONResponse) VisitGetChecklistByIdResponse(w http.ResponseWriter) error {
+func (response GetChecklist200JSONResponse) VisitGetChecklistResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetChecklistById400JSONResponse Error
+type GetChecklist400JSONResponse Error
 
-func (response GetChecklistById400JSONResponse) VisitGetChecklistByIdResponse(w http.ResponseWriter) error {
+func (response GetChecklist400JSONResponse) VisitGetChecklistResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(400)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetChecklistById404JSONResponse Error
+type GetChecklist404JSONResponse Error
 
-func (response GetChecklistById404JSONResponse) VisitGetChecklistByIdResponse(w http.ResponseWriter) error {
+func (response GetChecklist404JSONResponse) VisitGetChecklistResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(404)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetChecklistById500JSONResponse Error
+type GetChecklist500JSONResponse Error
 
-func (response GetChecklistById500JSONResponse) VisitGetChecklistByIdResponse(w http.ResponseWriter) error {
+func (response GetChecklist500JSONResponse) VisitGetChecklistResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type UpdateChecklistByIdRequestObject struct {
+type UpdateChecklistRequestObject struct {
 	ChecklistId uint `json:"checklistId"`
-	Body        *UpdateChecklistByIdJSONRequestBody
+	Body        *UpdateChecklistJSONRequestBody
 }
 
-type UpdateChecklistByIdResponseObject interface {
-	VisitUpdateChecklistByIdResponse(w http.ResponseWriter) error
+type UpdateChecklistResponseObject interface {
+	VisitUpdateChecklistResponse(w http.ResponseWriter) error
 }
 
-type UpdateChecklistById200JSONResponse ChecklistResponse
+type UpdateChecklist200JSONResponse ChecklistResponse
 
-func (response UpdateChecklistById200JSONResponse) VisitUpdateChecklistByIdResponse(w http.ResponseWriter) error {
+func (response UpdateChecklist200JSONResponse) VisitUpdateChecklistResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type UpdateChecklistById400JSONResponse Error
+type UpdateChecklist400JSONResponse Error
 
-func (response UpdateChecklistById400JSONResponse) VisitUpdateChecklistByIdResponse(w http.ResponseWriter) error {
+func (response UpdateChecklist400JSONResponse) VisitUpdateChecklistResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(400)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type UpdateChecklistById404JSONResponse Error
+type UpdateChecklist404JSONResponse Error
 
-func (response UpdateChecklistById404JSONResponse) VisitUpdateChecklistByIdResponse(w http.ResponseWriter) error {
+func (response UpdateChecklist404JSONResponse) VisitUpdateChecklistResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(404)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type UpdateChecklistById500JSONResponse Error
+type UpdateChecklist500JSONResponse Error
 
-func (response UpdateChecklistById500JSONResponse) VisitUpdateChecklistByIdResponse(w http.ResponseWriter) error {
+func (response UpdateChecklist500JSONResponse) VisitUpdateChecklistResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
@@ -411,21 +409,21 @@ func (response UpdateChecklistById500JSONResponse) VisitUpdateChecklistByIdRespo
 
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
-	// Get all checklists
+	// List all checklists
 	// (GET /api/v1/checklists)
-	GetAllChecklists(ctx context.Context, request GetAllChecklistsRequestObject) (GetAllChecklistsResponseObject, error)
+	ListChecklists(ctx context.Context, request ListChecklistsRequestObject) (ListChecklistsResponseObject, error)
 	// Create a new checklist
 	// (POST /api/v1/checklists)
 	CreateChecklist(ctx context.Context, request CreateChecklistRequestObject) (CreateChecklistResponseObject, error)
-	// Delete checklist by ID
+	// Delete a checklist
 	// (DELETE /api/v1/checklists/{checklistId})
-	DeleteChecklistById(ctx context.Context, request DeleteChecklistByIdRequestObject) (DeleteChecklistByIdResponseObject, error)
-	// Get checklist by ID
+	DeleteChecklist(ctx context.Context, request DeleteChecklistRequestObject) (DeleteChecklistResponseObject, error)
+	// Get a checklist
 	// (GET /api/v1/checklists/{checklistId})
-	GetChecklistById(ctx context.Context, request GetChecklistByIdRequestObject) (GetChecklistByIdResponseObject, error)
-	// Update checklist by ID
+	GetChecklist(ctx context.Context, request GetChecklistRequestObject) (GetChecklistResponseObject, error)
+	// Update a checklist
 	// (PUT /api/v1/checklists/{checklistId})
-	UpdateChecklistById(ctx context.Context, request UpdateChecklistByIdRequestObject) (UpdateChecklistByIdResponseObject, error)
+	UpdateChecklist(ctx context.Context, request UpdateChecklistRequestObject) (UpdateChecklistResponseObject, error)
 }
 
 type StrictHandlerFunc = strictgin.StrictGinHandlerFunc
@@ -440,15 +438,15 @@ type strictHandler struct {
 	middlewares []StrictMiddlewareFunc
 }
 
-// GetAllChecklists operation middleware
-func (sh *strictHandler) GetAllChecklists(ctx *gin.Context) {
-	var request GetAllChecklistsRequestObject
+// ListChecklists operation middleware
+func (sh *strictHandler) ListChecklists(ctx *gin.Context) {
+	var request ListChecklistsRequestObject
 
 	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.GetAllChecklists(ctx, request.(GetAllChecklistsRequestObject))
+		return sh.ssi.ListChecklists(ctx, request.(ListChecklistsRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "GetAllChecklists")
+		handler = middleware(handler, "ListChecklists")
 	}
 
 	response, err := handler(ctx, request)
@@ -456,8 +454,8 @@ func (sh *strictHandler) GetAllChecklists(ctx *gin.Context) {
 	if err != nil {
 		ctx.Error(err)
 		ctx.Status(http.StatusInternalServerError)
-	} else if validResponse, ok := response.(GetAllChecklistsResponseObject); ok {
-		if err := validResponse.VisitGetAllChecklistsResponse(ctx.Writer); err != nil {
+	} else if validResponse, ok := response.(ListChecklistsResponseObject); ok {
+		if err := validResponse.VisitListChecklistsResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
 	} else if response != nil {
@@ -498,17 +496,17 @@ func (sh *strictHandler) CreateChecklist(ctx *gin.Context) {
 	}
 }
 
-// DeleteChecklistById operation middleware
-func (sh *strictHandler) DeleteChecklistById(ctx *gin.Context, checklistId uint) {
-	var request DeleteChecklistByIdRequestObject
+// DeleteChecklist operation middleware
+func (sh *strictHandler) DeleteChecklist(ctx *gin.Context, checklistId uint) {
+	var request DeleteChecklistRequestObject
 
 	request.ChecklistId = checklistId
 
 	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.DeleteChecklistById(ctx, request.(DeleteChecklistByIdRequestObject))
+		return sh.ssi.DeleteChecklist(ctx, request.(DeleteChecklistRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "DeleteChecklistById")
+		handler = middleware(handler, "DeleteChecklist")
 	}
 
 	response, err := handler(ctx, request)
@@ -516,8 +514,8 @@ func (sh *strictHandler) DeleteChecklistById(ctx *gin.Context, checklistId uint)
 	if err != nil {
 		ctx.Error(err)
 		ctx.Status(http.StatusInternalServerError)
-	} else if validResponse, ok := response.(DeleteChecklistByIdResponseObject); ok {
-		if err := validResponse.VisitDeleteChecklistByIdResponse(ctx.Writer); err != nil {
+	} else if validResponse, ok := response.(DeleteChecklistResponseObject); ok {
+		if err := validResponse.VisitDeleteChecklistResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
 	} else if response != nil {
@@ -525,17 +523,17 @@ func (sh *strictHandler) DeleteChecklistById(ctx *gin.Context, checklistId uint)
 	}
 }
 
-// GetChecklistById operation middleware
-func (sh *strictHandler) GetChecklistById(ctx *gin.Context, checklistId uint) {
-	var request GetChecklistByIdRequestObject
+// GetChecklist operation middleware
+func (sh *strictHandler) GetChecklist(ctx *gin.Context, checklistId uint) {
+	var request GetChecklistRequestObject
 
 	request.ChecklistId = checklistId
 
 	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.GetChecklistById(ctx, request.(GetChecklistByIdRequestObject))
+		return sh.ssi.GetChecklist(ctx, request.(GetChecklistRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "GetChecklistById")
+		handler = middleware(handler, "GetChecklist")
 	}
 
 	response, err := handler(ctx, request)
@@ -543,8 +541,8 @@ func (sh *strictHandler) GetChecklistById(ctx *gin.Context, checklistId uint) {
 	if err != nil {
 		ctx.Error(err)
 		ctx.Status(http.StatusInternalServerError)
-	} else if validResponse, ok := response.(GetChecklistByIdResponseObject); ok {
-		if err := validResponse.VisitGetChecklistByIdResponse(ctx.Writer); err != nil {
+	} else if validResponse, ok := response.(GetChecklistResponseObject); ok {
+		if err := validResponse.VisitGetChecklistResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
 	} else if response != nil {
@@ -552,13 +550,13 @@ func (sh *strictHandler) GetChecklistById(ctx *gin.Context, checklistId uint) {
 	}
 }
 
-// UpdateChecklistById operation middleware
-func (sh *strictHandler) UpdateChecklistById(ctx *gin.Context, checklistId uint) {
-	var request UpdateChecklistByIdRequestObject
+// UpdateChecklist operation middleware
+func (sh *strictHandler) UpdateChecklist(ctx *gin.Context, checklistId uint) {
+	var request UpdateChecklistRequestObject
 
 	request.ChecklistId = checklistId
 
-	var body UpdateChecklistByIdJSONRequestBody
+	var body UpdateChecklistJSONRequestBody
 	if err := ctx.ShouldBindJSON(&body); err != nil {
 		ctx.Status(http.StatusBadRequest)
 		ctx.Error(err)
@@ -567,10 +565,10 @@ func (sh *strictHandler) UpdateChecklistById(ctx *gin.Context, checklistId uint)
 	request.Body = &body
 
 	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.UpdateChecklistById(ctx, request.(UpdateChecklistByIdRequestObject))
+		return sh.ssi.UpdateChecklist(ctx, request.(UpdateChecklistRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "UpdateChecklistById")
+		handler = middleware(handler, "UpdateChecklist")
 	}
 
 	response, err := handler(ctx, request)
@@ -578,8 +576,8 @@ func (sh *strictHandler) UpdateChecklistById(ctx *gin.Context, checklistId uint)
 	if err != nil {
 		ctx.Error(err)
 		ctx.Status(http.StatusInternalServerError)
-	} else if validResponse, ok := response.(UpdateChecklistByIdResponseObject); ok {
-		if err := validResponse.VisitUpdateChecklistByIdResponse(ctx.Writer); err != nil {
+	} else if validResponse, ok := response.(UpdateChecklistResponseObject); ok {
+		if err := validResponse.VisitUpdateChecklistResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
 	} else if response != nil {

--- a/internal/server/v1/checklistItem/checklist_item_controller_impl.go
+++ b/internal/server/v1/checklistItem/checklist_item_controller_impl.go
@@ -15,46 +15,52 @@ type checklistItemController struct {
 	mapper  IChecklistItemDtoMapper
 }
 
-func (controller *checklistItemController) GetAllChecklistItems(_ context.Context, request GetAllChecklistItemsRequestObject) (GetAllChecklistItemsResponseObject, error) {
+func (controller *checklistItemController) ListChecklistItems(_ context.Context, request ListChecklistItemsRequestObject) (ListChecklistItemsResponseObject, error) {
 	sortOrder, err := domain.NewSortOrder((*string)(request.Params.Sort))
 	if err != nil {
-		return GetAllChecklistItems400JSONResponse{
+		return ListChecklistItems400JSONResponse{
+			Code:    http.StatusBadRequest,
 			Message: err.Error(),
 		}, nil
 	}
 
 	if checklistItems, err := controller.service.FindAllChecklistItems(request.ChecklistId, request.Params.Completed, sortOrder); err == nil {
 		dto := controller.mapper.MapDomainListToDtoList(checklistItems)
-		return GetAllChecklistItems200JSONResponse(dto), nil
+		return ListChecklistItems200JSONResponse(dto), nil
 	} else if err.ResponseCode() == http.StatusBadRequest {
-		return GetAllChecklistItems400JSONResponse{
+		return ListChecklistItems400JSONResponse{
+			Code:    http.StatusBadRequest,
 			Message: err.Error(),
 		}, nil
 	} else {
-		return GetAllChecklistItems500JSONResponse{
+		return ListChecklistItems500JSONResponse{
+			Code:    http.StatusInternalServerError,
 			Message: err.Error(),
 		}, nil
 	}
 }
 
-func (controller *checklistItemController) DeleteChecklistItemById(_ context.Context, request DeleteChecklistItemByIdRequestObject) (DeleteChecklistItemByIdResponseObject, error) {
+func (controller *checklistItemController) DeleteChecklistItem(_ context.Context, request DeleteChecklistItemRequestObject) (DeleteChecklistItemResponseObject, error) {
 	if err := controller.service.DeleteChecklistItemById(request.ChecklistId, request.ItemId); err == nil {
-		return DeleteChecklistItemById204JSONResponse{}, nil
+		return DeleteChecklistItem204JSONResponse{}, nil
 	} else if err.ResponseCode() == http.StatusNotFound {
-		return DeleteChecklistItemById404JSONResponse{
+		return DeleteChecklistItem404JSONResponse{
+			Code:    http.StatusNotFound,
 			Message: err.Error(),
 		}, nil
 	} else {
-		return DeleteChecklistItemById500JSONResponse{
+		return DeleteChecklistItem500JSONResponse{
+			Code:    http.StatusInternalServerError,
 			Message: err.Error(),
 		}, nil
 	}
 }
 
-func (c *checklistItemController) ChangeChecklistItemOrderNumber(_ context.Context, request ChangeChecklistItemOrderNumberRequestObject) (ChangeChecklistItemOrderNumberResponseObject, error) {
+func (c *checklistItemController) ChangeChecklistItemOrder(_ context.Context, request ChangeChecklistItemOrderRequestObject) (ChangeChecklistItemOrderResponseObject, error) {
 	sortOrder, err := domain.NewSortOrder((*string)(request.Params.SortOrder))
 	if err != nil {
-		return ChangeChecklistItemOrderNumber400JSONResponse{
+		return ChangeChecklistItemOrder400JSONResponse{
+			Code:    http.StatusBadRequest,
 			Message: err.Error(),
 		}, nil
 	}
@@ -67,22 +73,25 @@ func (c *checklistItemController) ChangeChecklistItemOrderNumber(_ context.Conte
 	}
 
 	if response, err := c.service.ChangeChecklistItemOrder(changeOrderRequest); err == nil {
-		return ChangeChecklistItemOrderNumber200JSONResponse{
+		return ChangeChecklistItemOrder200JSONResponse{
 			NewOrderNumber: &response.OrderNumber,
 			OldOrderNumber: nil,
 		}, nil
 	} else {
 		switch err.ResponseCode() {
 		case http.StatusBadRequest:
-			return ChangeChecklistItemOrderNumber400JSONResponse{
+			return ChangeChecklistItemOrder400JSONResponse{
+				Code:    http.StatusBadRequest,
 				Message: err.Error(),
 			}, nil
 		case http.StatusNotFound:
-			return ChangeChecklistItemOrderNumber404JSONResponse{
+			return ChangeChecklistItemOrder404JSONResponse{
+				Code:    http.StatusNotFound,
 				Message: err.Error(),
 			}, nil
 		default:
-			return ChangeChecklistItemOrderNumber500JSONResponse{
+			return ChangeChecklistItemOrder500JSONResponse{
+				Code:    http.StatusInternalServerError,
 				Message: err.Error(),
 			}, nil
 		}
@@ -96,10 +105,12 @@ func (c *checklistItemController) CreateChecklistItem(_ context.Context, request
 		return CreateChecklistItem201JSONResponse(dto), nil
 	} else if err.ResponseCode() == http.StatusBadRequest {
 		return CreateChecklistItem400JSONResponse{
+			Code:    http.StatusBadRequest,
 			Message: err.Error(),
 		}, nil
 	} else {
 		return CreateChecklistItem500JSONResponse{
+			Code:    http.StatusInternalServerError,
 			Message: err.Error(),
 		}, nil
 	}
@@ -113,42 +124,45 @@ func (c *checklistItemController) CreateChecklistItemRow(_ context.Context, requ
 	} else {
 		switch err.ResponseCode() {
 		case http.StatusBadRequest:
-			return CreateChecklistItemRow400JSONResponse{Message: err.Error()}, nil
+			return CreateChecklistItemRow400JSONResponse{Code: http.StatusBadRequest, Message: err.Error()}, nil
 		case http.StatusNotFound:
-			return CreateChecklistItemRow404JSONResponse{Message: err.Error()}, nil
+			return CreateChecklistItemRow404JSONResponse{Code: http.StatusNotFound, Message: err.Error()}, nil
 		default:
-			return CreateChecklistItemRow500JSONResponse{Message: err.Error()}, nil
+			return CreateChecklistItemRow500JSONResponse{Code: http.StatusInternalServerError, Message: err.Error()}, nil
 		}
 	}
 }
 
-func (c *checklistItemController) GetChecklistItemBychecklistIdAndItemId(_ context.Context, request GetChecklistItemBychecklistIdAndItemIdRequestObject) (GetChecklistItemBychecklistIdAndItemIdResponseObject, error) {
+func (c *checklistItemController) GetChecklistItem(_ context.Context, request GetChecklistItemRequestObject) (GetChecklistItemResponseObject, error) {
 	if checklistItem, err := c.service.FindChecklistItemById(request.ChecklistId, request.ItemId); err != nil {
-		return GetChecklistItemBychecklistIdAndItemId500JSONResponse{Message: err.Error()}, nil
+		return GetChecklistItem500JSONResponse{Code: http.StatusInternalServerError, Message: err.Error()}, nil
 	} else if checklistItem == nil {
-		return GetChecklistItemBychecklistIdAndItemId404JSONResponse{
+		return GetChecklistItem404JSONResponse{
+			Code:    http.StatusNotFound,
 			Message: "Checklist item not found",
 		}, nil
 	} else {
 		dto := c.mapper.MapDomainToDto(*checklistItem)
-		return GetChecklistItemBychecklistIdAndItemId200JSONResponse(dto), nil
+		return GetChecklistItem200JSONResponse(dto), nil
 	}
 }
 
-func (c *checklistItemController) UpdateChecklistItemBychecklistIdAndItemId(_ context.Context, request UpdateChecklistItemBychecklistIdAndItemIdRequestObject) (UpdateChecklistItemBychecklistIdAndItemIdResponseObject, error) {
+func (c *checklistItemController) UpdateChecklistItem(_ context.Context, request UpdateChecklistItemRequestObject) (UpdateChecklistItemResponseObject, error) {
 	domainObject := c.mapper.MapUpdateRequestToDomain(*request.Body)
 	domainObject.Id = request.ItemId
 	if updatedItem, err := c.service.UpdateChecklistItem(request.ChecklistId, domainObject); err != nil && err.ResponseCode() == 404 {
-		return UpdateChecklistItemBychecklistIdAndItemId404JSONResponse{
+		return UpdateChecklistItem404JSONResponse{
+			Code:    http.StatusNotFound,
 			Message: err.Error(),
 		}, nil
 	} else if err != nil && err.ResponseCode() == 500 {
-		return UpdateChecklistItemBychecklistIdAndItemId500JSONResponse{
+		return UpdateChecklistItem500JSONResponse{
+			Code:    http.StatusInternalServerError,
 			Message: err.Error(),
 		}, nil
 	} else {
 		dto := c.mapper.MapDomainToDto(updatedItem)
-		return UpdateChecklistItemBychecklistIdAndItemId200JSONResponse(dto), nil
+		return UpdateChecklistItem200JSONResponse(dto), nil
 	}
 }
 

--- a/internal/server/v1/checklistItem/server.gen.go
+++ b/internal/server/v1/checklistItem/server.gen.go
@@ -14,16 +14,16 @@ import (
 	strictgin "github.com/oapi-codegen/runtime/strictmiddleware/gin"
 )
 
-// Defines values for GetAllChecklistItemsParamsSort.
+// Defines values for ListChecklistItemsParamsSort.
 const (
-	GetAllChecklistItemsParamsSortAsc  GetAllChecklistItemsParamsSort = "asc"
-	GetAllChecklistItemsParamsSortDesc GetAllChecklistItemsParamsSort = "desc"
+	ListChecklistItemsParamsSortAsc  ListChecklistItemsParamsSort = "asc"
+	ListChecklistItemsParamsSortDesc ListChecklistItemsParamsSort = "desc"
 )
 
-// Defines values for ChangeChecklistItemOrderNumberParamsSortOrder.
+// Defines values for ChangeChecklistItemOrderParamsSortOrder.
 const (
-	ChangeChecklistItemOrderNumberParamsSortOrderAsc  ChangeChecklistItemOrderNumberParamsSortOrder = "asc"
-	ChangeChecklistItemOrderNumberParamsSortOrderDesc ChangeChecklistItemOrderNumberParamsSortOrder = "desc"
+	ChangeChecklistItemOrderParamsSortOrderAsc  ChangeChecklistItemOrderParamsSortOrder = "asc"
+	ChangeChecklistItemOrderParamsSortOrderDesc ChangeChecklistItemOrderParamsSortOrder = "desc"
 )
 
 // ChecklistItemResponse defines model for ChecklistItemResponse.
@@ -59,13 +59,13 @@ type CreateOrUpdateChecklistItemRowRequest struct {
 
 // Error defines model for Error.
 type Error struct {
+	Code    int32  `json:"code"`
 	Message string `json:"message"`
 }
 
 // UpdateChecklistItemRequest defines model for UpdateChecklistItemRequest.
 type UpdateChecklistItemRequest struct {
 	Completed bool   `json:"completed"`
-	Id        uint   `json:"id"`
 	Name      string `json:"name"`
 	Rows      []struct {
 		Completed *bool  `json:"completed"`
@@ -74,64 +74,64 @@ type UpdateChecklistItemRequest struct {
 	} `json:"rows"`
 }
 
-// GetAllChecklistItemsParams defines parameters for GetAllChecklistItems.
-type GetAllChecklistItemsParams struct {
+// ListChecklistItemsParams defines parameters for ListChecklistItems.
+type ListChecklistItemsParams struct {
 	// Sort Sort order
-	Sort *GetAllChecklistItemsParamsSort `form:"sort,omitempty" json:"sort,omitempty"`
+	Sort *ListChecklistItemsParamsSort `form:"sort,omitempty" json:"sort,omitempty"`
 
 	// Completed Filter by completed status
 	Completed *bool `form:"completed,omitempty" json:"completed,omitempty"`
 }
 
-// GetAllChecklistItemsParamsSort defines parameters for GetAllChecklistItems.
-type GetAllChecklistItemsParamsSort string
+// ListChecklistItemsParamsSort defines parameters for ListChecklistItems.
+type ListChecklistItemsParamsSort string
 
-// ChangeChecklistItemOrderNumberJSONBody defines parameters for ChangeChecklistItemOrderNumber.
-type ChangeChecklistItemOrderNumberJSONBody struct {
+// ChangeChecklistItemOrderJSONBody defines parameters for ChangeChecklistItemOrder.
+type ChangeChecklistItemOrderJSONBody struct {
 	NewOrderNumber uint `json:"newOrderNumber"`
 }
 
-// ChangeChecklistItemOrderNumberParams defines parameters for ChangeChecklistItemOrderNumber.
-type ChangeChecklistItemOrderNumberParams struct {
-	SortOrder *ChangeChecklistItemOrderNumberParamsSortOrder `form:"sortOrder,omitempty" json:"sortOrder,omitempty"`
+// ChangeChecklistItemOrderParams defines parameters for ChangeChecklistItemOrder.
+type ChangeChecklistItemOrderParams struct {
+	SortOrder *ChangeChecklistItemOrderParamsSortOrder `form:"sortOrder,omitempty" json:"sortOrder,omitempty"`
 }
 
-// ChangeChecklistItemOrderNumberParamsSortOrder defines parameters for ChangeChecklistItemOrderNumber.
-type ChangeChecklistItemOrderNumberParamsSortOrder string
+// ChangeChecklistItemOrderParamsSortOrder defines parameters for ChangeChecklistItemOrder.
+type ChangeChecklistItemOrderParamsSortOrder string
 
 // CreateChecklistItemJSONRequestBody defines body for CreateChecklistItem for application/json ContentType.
 type CreateChecklistItemJSONRequestBody = CreateChecklistItemRequest
 
-// UpdateChecklistItemBychecklistIdAndItemIdJSONRequestBody defines body for UpdateChecklistItemBychecklistIdAndItemId for application/json ContentType.
-type UpdateChecklistItemBychecklistIdAndItemIdJSONRequestBody = UpdateChecklistItemRequest
+// UpdateChecklistItemJSONRequestBody defines body for UpdateChecklistItem for application/json ContentType.
+type UpdateChecklistItemJSONRequestBody = UpdateChecklistItemRequest
 
-// ChangeChecklistItemOrderNumberJSONRequestBody defines body for ChangeChecklistItemOrderNumber for application/json ContentType.
-type ChangeChecklistItemOrderNumberJSONRequestBody ChangeChecklistItemOrderNumberJSONBody
+// ChangeChecklistItemOrderJSONRequestBody defines body for ChangeChecklistItemOrder for application/json ContentType.
+type ChangeChecklistItemOrderJSONRequestBody ChangeChecklistItemOrderJSONBody
 
 // CreateChecklistItemRowJSONRequestBody defines body for CreateChecklistItemRow for application/json ContentType.
 type CreateChecklistItemRowJSONRequestBody = CreateChecklistItemRowRequest
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
-	// Get all checklist items by checklist ID
+	// List checklist items
 	// (GET /api/v1/checklists/{checklistId}/items)
-	GetAllChecklistItems(c *gin.Context, checklistId uint, params GetAllChecklistItemsParams)
-	// Create a new checklist item
+	ListChecklistItems(c *gin.Context, checklistId uint, params ListChecklistItemsParams)
+	// Create a checklist item
 	// (POST /api/v1/checklists/{checklistId}/items)
 	CreateChecklistItem(c *gin.Context, checklistId uint)
-	// Delete checklist item by checklistId and checklistItemId
+	// Delete a checklist item
 	// (DELETE /api/v1/checklists/{checklistId}/items/{itemId})
-	DeleteChecklistItemById(c *gin.Context, checklistId uint, itemId uint)
-	// Get checklist item by checklist id and item id
+	DeleteChecklistItem(c *gin.Context, checklistId uint, itemId uint)
+	// Get a checklist item
 	// (GET /api/v1/checklists/{checklistId}/items/{itemId})
-	GetChecklistItemBychecklistIdAndItemId(c *gin.Context, checklistId uint, itemId uint)
-	// Update checklist item by checklist id and item id
+	GetChecklistItem(c *gin.Context, checklistId uint, itemId uint)
+	// Update a checklist item
 	// (PUT /api/v1/checklists/{checklistId}/items/{itemId})
-	UpdateChecklistItemBychecklistIdAndItemId(c *gin.Context, checklistId uint, itemId uint)
-	// Change checklist item order number
+	UpdateChecklistItem(c *gin.Context, checklistId uint, itemId uint)
+	// Change checklist item order
 	// (PATCH /api/v1/checklists/{checklistId}/items/{itemId}/change-order)
-	ChangeChecklistItemOrderNumber(c *gin.Context, checklistId uint, itemId uint, params ChangeChecklistItemOrderNumberParams)
-	// Create checklist item row
+	ChangeChecklistItemOrder(c *gin.Context, checklistId uint, itemId uint, params ChangeChecklistItemOrderParams)
+	// Create a checklist item row
 	// (POST /api/v1/checklists/{checklistId}/items/{itemId}/rows)
 	CreateChecklistItemRow(c *gin.Context, checklistId uint, itemId uint)
 }
@@ -145,8 +145,8 @@ type ServerInterfaceWrapper struct {
 
 type MiddlewareFunc func(c *gin.Context)
 
-// GetAllChecklistItems operation middleware
-func (siw *ServerInterfaceWrapper) GetAllChecklistItems(c *gin.Context) {
+// ListChecklistItems operation middleware
+func (siw *ServerInterfaceWrapper) ListChecklistItems(c *gin.Context) {
 
 	var err error
 
@@ -160,7 +160,7 @@ func (siw *ServerInterfaceWrapper) GetAllChecklistItems(c *gin.Context) {
 	}
 
 	// Parameter object where we will unmarshal all parameters from the context
-	var params GetAllChecklistItemsParams
+	var params ListChecklistItemsParams
 
 	// ------------- Optional query parameter "sort" -------------
 
@@ -185,7 +185,7 @@ func (siw *ServerInterfaceWrapper) GetAllChecklistItems(c *gin.Context) {
 		}
 	}
 
-	siw.Handler.GetAllChecklistItems(c, checklistId, params)
+	siw.Handler.ListChecklistItems(c, checklistId, params)
 }
 
 // CreateChecklistItem operation middleware
@@ -212,8 +212,8 @@ func (siw *ServerInterfaceWrapper) CreateChecklistItem(c *gin.Context) {
 	siw.Handler.CreateChecklistItem(c, checklistId)
 }
 
-// DeleteChecklistItemById operation middleware
-func (siw *ServerInterfaceWrapper) DeleteChecklistItemById(c *gin.Context) {
+// DeleteChecklistItem operation middleware
+func (siw *ServerInterfaceWrapper) DeleteChecklistItem(c *gin.Context) {
 
 	var err error
 
@@ -242,11 +242,11 @@ func (siw *ServerInterfaceWrapper) DeleteChecklistItemById(c *gin.Context) {
 		}
 	}
 
-	siw.Handler.DeleteChecklistItemById(c, checklistId, itemId)
+	siw.Handler.DeleteChecklistItem(c, checklistId, itemId)
 }
 
-// GetChecklistItemBychecklistIdAndItemId operation middleware
-func (siw *ServerInterfaceWrapper) GetChecklistItemBychecklistIdAndItemId(c *gin.Context) {
+// GetChecklistItem operation middleware
+func (siw *ServerInterfaceWrapper) GetChecklistItem(c *gin.Context) {
 
 	var err error
 
@@ -275,11 +275,11 @@ func (siw *ServerInterfaceWrapper) GetChecklistItemBychecklistIdAndItemId(c *gin
 		}
 	}
 
-	siw.Handler.GetChecklistItemBychecklistIdAndItemId(c, checklistId, itemId)
+	siw.Handler.GetChecklistItem(c, checklistId, itemId)
 }
 
-// UpdateChecklistItemBychecklistIdAndItemId operation middleware
-func (siw *ServerInterfaceWrapper) UpdateChecklistItemBychecklistIdAndItemId(c *gin.Context) {
+// UpdateChecklistItem operation middleware
+func (siw *ServerInterfaceWrapper) UpdateChecklistItem(c *gin.Context) {
 
 	var err error
 
@@ -308,11 +308,11 @@ func (siw *ServerInterfaceWrapper) UpdateChecklistItemBychecklistIdAndItemId(c *
 		}
 	}
 
-	siw.Handler.UpdateChecklistItemBychecklistIdAndItemId(c, checklistId, itemId)
+	siw.Handler.UpdateChecklistItem(c, checklistId, itemId)
 }
 
-// ChangeChecklistItemOrderNumber operation middleware
-func (siw *ServerInterfaceWrapper) ChangeChecklistItemOrderNumber(c *gin.Context) {
+// ChangeChecklistItemOrder operation middleware
+func (siw *ServerInterfaceWrapper) ChangeChecklistItemOrder(c *gin.Context) {
 
 	var err error
 
@@ -335,7 +335,7 @@ func (siw *ServerInterfaceWrapper) ChangeChecklistItemOrderNumber(c *gin.Context
 	}
 
 	// Parameter object where we will unmarshal all parameters from the context
-	var params ChangeChecklistItemOrderNumberParams
+	var params ChangeChecklistItemOrderParams
 
 	// ------------- Optional query parameter "sortOrder" -------------
 
@@ -352,7 +352,7 @@ func (siw *ServerInterfaceWrapper) ChangeChecklistItemOrderNumber(c *gin.Context
 		}
 	}
 
-	siw.Handler.ChangeChecklistItemOrderNumber(c, checklistId, itemId, params)
+	siw.Handler.ChangeChecklistItemOrder(c, checklistId, itemId, params)
 }
 
 // CreateChecklistItemRow operation middleware
@@ -415,45 +415,45 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 		ErrorHandler:       errorHandler,
 	}
 
-	router.GET(options.BaseURL+"/api/v1/checklists/:checklistId/items", wrapper.GetAllChecklistItems)
+	router.GET(options.BaseURL+"/api/v1/checklists/:checklistId/items", wrapper.ListChecklistItems)
 	router.POST(options.BaseURL+"/api/v1/checklists/:checklistId/items", wrapper.CreateChecklistItem)
-	router.DELETE(options.BaseURL+"/api/v1/checklists/:checklistId/items/:itemId", wrapper.DeleteChecklistItemById)
-	router.GET(options.BaseURL+"/api/v1/checklists/:checklistId/items/:itemId", wrapper.GetChecklistItemBychecklistIdAndItemId)
-	router.PUT(options.BaseURL+"/api/v1/checklists/:checklistId/items/:itemId", wrapper.UpdateChecklistItemBychecklistIdAndItemId)
-	router.PATCH(options.BaseURL+"/api/v1/checklists/:checklistId/items/:itemId/change-order", wrapper.ChangeChecklistItemOrderNumber)
+	router.DELETE(options.BaseURL+"/api/v1/checklists/:checklistId/items/:itemId", wrapper.DeleteChecklistItem)
+	router.GET(options.BaseURL+"/api/v1/checklists/:checklistId/items/:itemId", wrapper.GetChecklistItem)
+	router.PUT(options.BaseURL+"/api/v1/checklists/:checklistId/items/:itemId", wrapper.UpdateChecklistItem)
+	router.PATCH(options.BaseURL+"/api/v1/checklists/:checklistId/items/:itemId/change-order", wrapper.ChangeChecklistItemOrder)
 	router.POST(options.BaseURL+"/api/v1/checklists/:checklistId/items/:itemId/rows", wrapper.CreateChecklistItemRow)
 }
 
-type GetAllChecklistItemsRequestObject struct {
+type ListChecklistItemsRequestObject struct {
 	ChecklistId uint `json:"checklistId"`
-	Params      GetAllChecklistItemsParams
+	Params      ListChecklistItemsParams
 }
 
-type GetAllChecklistItemsResponseObject interface {
-	VisitGetAllChecklistItemsResponse(w http.ResponseWriter) error
+type ListChecklistItemsResponseObject interface {
+	VisitListChecklistItemsResponse(w http.ResponseWriter) error
 }
 
-type GetAllChecklistItems200JSONResponse []ChecklistItemResponse
+type ListChecklistItems200JSONResponse []ChecklistItemResponse
 
-func (response GetAllChecklistItems200JSONResponse) VisitGetAllChecklistItemsResponse(w http.ResponseWriter) error {
+func (response ListChecklistItems200JSONResponse) VisitListChecklistItemsResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetAllChecklistItems400JSONResponse Error
+type ListChecklistItems400JSONResponse Error
 
-func (response GetAllChecklistItems400JSONResponse) VisitGetAllChecklistItemsResponse(w http.ResponseWriter) error {
+func (response ListChecklistItems400JSONResponse) VisitListChecklistItemsResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(400)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetAllChecklistItems500JSONResponse Error
+type ListChecklistItems500JSONResponse Error
 
-func (response GetAllChecklistItems500JSONResponse) VisitGetAllChecklistItemsResponse(w http.ResponseWriter) error {
+func (response ListChecklistItems500JSONResponse) VisitListChecklistItemsResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
@@ -496,159 +496,159 @@ func (response CreateChecklistItem500JSONResponse) VisitCreateChecklistItemRespo
 	return json.NewEncoder(w).Encode(response)
 }
 
-type DeleteChecklistItemByIdRequestObject struct {
+type DeleteChecklistItemRequestObject struct {
 	ChecklistId uint `json:"checklistId"`
 	ItemId      uint `json:"itemId"`
 }
 
-type DeleteChecklistItemByIdResponseObject interface {
-	VisitDeleteChecklistItemByIdResponse(w http.ResponseWriter) error
+type DeleteChecklistItemResponseObject interface {
+	VisitDeleteChecklistItemResponse(w http.ResponseWriter) error
 }
 
-type DeleteChecklistItemById204JSONResponse ChecklistItemResponse
+type DeleteChecklistItem204JSONResponse ChecklistItemResponse
 
-func (response DeleteChecklistItemById204JSONResponse) VisitDeleteChecklistItemByIdResponse(w http.ResponseWriter) error {
+func (response DeleteChecklistItem204JSONResponse) VisitDeleteChecklistItemResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(204)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type DeleteChecklistItemById404JSONResponse Error
+type DeleteChecklistItem404JSONResponse Error
 
-func (response DeleteChecklistItemById404JSONResponse) VisitDeleteChecklistItemByIdResponse(w http.ResponseWriter) error {
+func (response DeleteChecklistItem404JSONResponse) VisitDeleteChecklistItemResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(404)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type DeleteChecklistItemById500JSONResponse Error
+type DeleteChecklistItem500JSONResponse Error
 
-func (response DeleteChecklistItemById500JSONResponse) VisitDeleteChecklistItemByIdResponse(w http.ResponseWriter) error {
+func (response DeleteChecklistItem500JSONResponse) VisitDeleteChecklistItemResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetChecklistItemBychecklistIdAndItemIdRequestObject struct {
+type GetChecklistItemRequestObject struct {
 	ChecklistId uint `json:"checklistId"`
 	ItemId      uint `json:"itemId"`
 }
 
-type GetChecklistItemBychecklistIdAndItemIdResponseObject interface {
-	VisitGetChecklistItemBychecklistIdAndItemIdResponse(w http.ResponseWriter) error
+type GetChecklistItemResponseObject interface {
+	VisitGetChecklistItemResponse(w http.ResponseWriter) error
 }
 
-type GetChecklistItemBychecklistIdAndItemId200JSONResponse ChecklistItemResponse
+type GetChecklistItem200JSONResponse ChecklistItemResponse
 
-func (response GetChecklistItemBychecklistIdAndItemId200JSONResponse) VisitGetChecklistItemBychecklistIdAndItemIdResponse(w http.ResponseWriter) error {
+func (response GetChecklistItem200JSONResponse) VisitGetChecklistItemResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetChecklistItemBychecklistIdAndItemId404JSONResponse Error
+type GetChecklistItem404JSONResponse Error
 
-func (response GetChecklistItemBychecklistIdAndItemId404JSONResponse) VisitGetChecklistItemBychecklistIdAndItemIdResponse(w http.ResponseWriter) error {
+func (response GetChecklistItem404JSONResponse) VisitGetChecklistItemResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(404)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetChecklistItemBychecklistIdAndItemId500JSONResponse Error
+type GetChecklistItem500JSONResponse Error
 
-func (response GetChecklistItemBychecklistIdAndItemId500JSONResponse) VisitGetChecklistItemBychecklistIdAndItemIdResponse(w http.ResponseWriter) error {
+func (response GetChecklistItem500JSONResponse) VisitGetChecklistItemResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type UpdateChecklistItemBychecklistIdAndItemIdRequestObject struct {
+type UpdateChecklistItemRequestObject struct {
 	ChecklistId uint `json:"checklistId"`
 	ItemId      uint `json:"itemId"`
-	Body        *UpdateChecklistItemBychecklistIdAndItemIdJSONRequestBody
+	Body        *UpdateChecklistItemJSONRequestBody
 }
 
-type UpdateChecklistItemBychecklistIdAndItemIdResponseObject interface {
-	VisitUpdateChecklistItemBychecklistIdAndItemIdResponse(w http.ResponseWriter) error
+type UpdateChecklistItemResponseObject interface {
+	VisitUpdateChecklistItemResponse(w http.ResponseWriter) error
 }
 
-type UpdateChecklistItemBychecklistIdAndItemId200JSONResponse ChecklistItemResponse
+type UpdateChecklistItem200JSONResponse ChecklistItemResponse
 
-func (response UpdateChecklistItemBychecklistIdAndItemId200JSONResponse) VisitUpdateChecklistItemBychecklistIdAndItemIdResponse(w http.ResponseWriter) error {
+func (response UpdateChecklistItem200JSONResponse) VisitUpdateChecklistItemResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type UpdateChecklistItemBychecklistIdAndItemId404JSONResponse Error
+type UpdateChecklistItem404JSONResponse Error
 
-func (response UpdateChecklistItemBychecklistIdAndItemId404JSONResponse) VisitUpdateChecklistItemBychecklistIdAndItemIdResponse(w http.ResponseWriter) error {
+func (response UpdateChecklistItem404JSONResponse) VisitUpdateChecklistItemResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(404)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type UpdateChecklistItemBychecklistIdAndItemId500JSONResponse Error
+type UpdateChecklistItem500JSONResponse Error
 
-func (response UpdateChecklistItemBychecklistIdAndItemId500JSONResponse) VisitUpdateChecklistItemBychecklistIdAndItemIdResponse(w http.ResponseWriter) error {
+func (response UpdateChecklistItem500JSONResponse) VisitUpdateChecklistItemResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type ChangeChecklistItemOrderNumberRequestObject struct {
+type ChangeChecklistItemOrderRequestObject struct {
 	ChecklistId uint `json:"checklistId"`
 	ItemId      uint `json:"itemId"`
-	Params      ChangeChecklistItemOrderNumberParams
-	Body        *ChangeChecklistItemOrderNumberJSONRequestBody
+	Params      ChangeChecklistItemOrderParams
+	Body        *ChangeChecklistItemOrderJSONRequestBody
 }
 
-type ChangeChecklistItemOrderNumberResponseObject interface {
-	VisitChangeChecklistItemOrderNumberResponse(w http.ResponseWriter) error
+type ChangeChecklistItemOrderResponseObject interface {
+	VisitChangeChecklistItemOrderResponse(w http.ResponseWriter) error
 }
 
-type ChangeChecklistItemOrderNumber200JSONResponse struct {
+type ChangeChecklistItemOrder200JSONResponse struct {
 	NewOrderNumber *uint `json:"newOrderNumber,omitempty"`
 	OldOrderNumber *uint `json:"oldOrderNumber,omitempty"`
 }
 
-func (response ChangeChecklistItemOrderNumber200JSONResponse) VisitChangeChecklistItemOrderNumberResponse(w http.ResponseWriter) error {
+func (response ChangeChecklistItemOrder200JSONResponse) VisitChangeChecklistItemOrderResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type ChangeChecklistItemOrderNumber400JSONResponse Error
+type ChangeChecklistItemOrder400JSONResponse Error
 
-func (response ChangeChecklistItemOrderNumber400JSONResponse) VisitChangeChecklistItemOrderNumberResponse(w http.ResponseWriter) error {
+func (response ChangeChecklistItemOrder400JSONResponse) VisitChangeChecklistItemOrderResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(400)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type ChangeChecklistItemOrderNumber404JSONResponse Error
+type ChangeChecklistItemOrder404JSONResponse Error
 
-func (response ChangeChecklistItemOrderNumber404JSONResponse) VisitChangeChecklistItemOrderNumberResponse(w http.ResponseWriter) error {
+func (response ChangeChecklistItemOrder404JSONResponse) VisitChangeChecklistItemOrderResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(404)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type ChangeChecklistItemOrderNumber500JSONResponse Error
+type ChangeChecklistItemOrder500JSONResponse Error
 
-func (response ChangeChecklistItemOrderNumber500JSONResponse) VisitChangeChecklistItemOrderNumberResponse(w http.ResponseWriter) error {
+func (response ChangeChecklistItemOrder500JSONResponse) VisitChangeChecklistItemOrderResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
@@ -703,25 +703,25 @@ func (response CreateChecklistItemRow500JSONResponse) VisitCreateChecklistItemRo
 
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
-	// Get all checklist items by checklist ID
+	// List checklist items
 	// (GET /api/v1/checklists/{checklistId}/items)
-	GetAllChecklistItems(ctx context.Context, request GetAllChecklistItemsRequestObject) (GetAllChecklistItemsResponseObject, error)
-	// Create a new checklist item
+	ListChecklistItems(ctx context.Context, request ListChecklistItemsRequestObject) (ListChecklistItemsResponseObject, error)
+	// Create a checklist item
 	// (POST /api/v1/checklists/{checklistId}/items)
 	CreateChecklistItem(ctx context.Context, request CreateChecklistItemRequestObject) (CreateChecklistItemResponseObject, error)
-	// Delete checklist item by checklistId and checklistItemId
+	// Delete a checklist item
 	// (DELETE /api/v1/checklists/{checklistId}/items/{itemId})
-	DeleteChecklistItemById(ctx context.Context, request DeleteChecklistItemByIdRequestObject) (DeleteChecklistItemByIdResponseObject, error)
-	// Get checklist item by checklist id and item id
+	DeleteChecklistItem(ctx context.Context, request DeleteChecklistItemRequestObject) (DeleteChecklistItemResponseObject, error)
+	// Get a checklist item
 	// (GET /api/v1/checklists/{checklistId}/items/{itemId})
-	GetChecklistItemBychecklistIdAndItemId(ctx context.Context, request GetChecklistItemBychecklistIdAndItemIdRequestObject) (GetChecklistItemBychecklistIdAndItemIdResponseObject, error)
-	// Update checklist item by checklist id and item id
+	GetChecklistItem(ctx context.Context, request GetChecklistItemRequestObject) (GetChecklistItemResponseObject, error)
+	// Update a checklist item
 	// (PUT /api/v1/checklists/{checklistId}/items/{itemId})
-	UpdateChecklistItemBychecklistIdAndItemId(ctx context.Context, request UpdateChecklistItemBychecklistIdAndItemIdRequestObject) (UpdateChecklistItemBychecklistIdAndItemIdResponseObject, error)
-	// Change checklist item order number
+	UpdateChecklistItem(ctx context.Context, request UpdateChecklistItemRequestObject) (UpdateChecklistItemResponseObject, error)
+	// Change checklist item order
 	// (PATCH /api/v1/checklists/{checklistId}/items/{itemId}/change-order)
-	ChangeChecklistItemOrderNumber(ctx context.Context, request ChangeChecklistItemOrderNumberRequestObject) (ChangeChecklistItemOrderNumberResponseObject, error)
-	// Create checklist item row
+	ChangeChecklistItemOrder(ctx context.Context, request ChangeChecklistItemOrderRequestObject) (ChangeChecklistItemOrderResponseObject, error)
+	// Create a checklist item row
 	// (POST /api/v1/checklists/{checklistId}/items/{itemId}/rows)
 	CreateChecklistItemRow(ctx context.Context, request CreateChecklistItemRowRequestObject) (CreateChecklistItemRowResponseObject, error)
 }
@@ -738,18 +738,18 @@ type strictHandler struct {
 	middlewares []StrictMiddlewareFunc
 }
 
-// GetAllChecklistItems operation middleware
-func (sh *strictHandler) GetAllChecklistItems(ctx *gin.Context, checklistId uint, params GetAllChecklistItemsParams) {
-	var request GetAllChecklistItemsRequestObject
+// ListChecklistItems operation middleware
+func (sh *strictHandler) ListChecklistItems(ctx *gin.Context, checklistId uint, params ListChecklistItemsParams) {
+	var request ListChecklistItemsRequestObject
 
 	request.ChecklistId = checklistId
 	request.Params = params
 
 	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.GetAllChecklistItems(ctx, request.(GetAllChecklistItemsRequestObject))
+		return sh.ssi.ListChecklistItems(ctx, request.(ListChecklistItemsRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "GetAllChecklistItems")
+		handler = middleware(handler, "ListChecklistItems")
 	}
 
 	response, err := handler(ctx, request)
@@ -757,8 +757,8 @@ func (sh *strictHandler) GetAllChecklistItems(ctx *gin.Context, checklistId uint
 	if err != nil {
 		ctx.Error(err)
 		ctx.Status(http.StatusInternalServerError)
-	} else if validResponse, ok := response.(GetAllChecklistItemsResponseObject); ok {
-		if err := validResponse.VisitGetAllChecklistItemsResponse(ctx.Writer); err != nil {
+	} else if validResponse, ok := response.(ListChecklistItemsResponseObject); ok {
+		if err := validResponse.VisitListChecklistItemsResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
 	} else if response != nil {
@@ -801,18 +801,18 @@ func (sh *strictHandler) CreateChecklistItem(ctx *gin.Context, checklistId uint)
 	}
 }
 
-// DeleteChecklistItemById operation middleware
-func (sh *strictHandler) DeleteChecklistItemById(ctx *gin.Context, checklistId uint, itemId uint) {
-	var request DeleteChecklistItemByIdRequestObject
+// DeleteChecklistItem operation middleware
+func (sh *strictHandler) DeleteChecklistItem(ctx *gin.Context, checklistId uint, itemId uint) {
+	var request DeleteChecklistItemRequestObject
 
 	request.ChecklistId = checklistId
 	request.ItemId = itemId
 
 	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.DeleteChecklistItemById(ctx, request.(DeleteChecklistItemByIdRequestObject))
+		return sh.ssi.DeleteChecklistItem(ctx, request.(DeleteChecklistItemRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "DeleteChecklistItemById")
+		handler = middleware(handler, "DeleteChecklistItem")
 	}
 
 	response, err := handler(ctx, request)
@@ -820,8 +820,8 @@ func (sh *strictHandler) DeleteChecklistItemById(ctx *gin.Context, checklistId u
 	if err != nil {
 		ctx.Error(err)
 		ctx.Status(http.StatusInternalServerError)
-	} else if validResponse, ok := response.(DeleteChecklistItemByIdResponseObject); ok {
-		if err := validResponse.VisitDeleteChecklistItemByIdResponse(ctx.Writer); err != nil {
+	} else if validResponse, ok := response.(DeleteChecklistItemResponseObject); ok {
+		if err := validResponse.VisitDeleteChecklistItemResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
 	} else if response != nil {
@@ -829,18 +829,18 @@ func (sh *strictHandler) DeleteChecklistItemById(ctx *gin.Context, checklistId u
 	}
 }
 
-// GetChecklistItemBychecklistIdAndItemId operation middleware
-func (sh *strictHandler) GetChecklistItemBychecklistIdAndItemId(ctx *gin.Context, checklistId uint, itemId uint) {
-	var request GetChecklistItemBychecklistIdAndItemIdRequestObject
+// GetChecklistItem operation middleware
+func (sh *strictHandler) GetChecklistItem(ctx *gin.Context, checklistId uint, itemId uint) {
+	var request GetChecklistItemRequestObject
 
 	request.ChecklistId = checklistId
 	request.ItemId = itemId
 
 	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.GetChecklistItemBychecklistIdAndItemId(ctx, request.(GetChecklistItemBychecklistIdAndItemIdRequestObject))
+		return sh.ssi.GetChecklistItem(ctx, request.(GetChecklistItemRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "GetChecklistItemBychecklistIdAndItemId")
+		handler = middleware(handler, "GetChecklistItem")
 	}
 
 	response, err := handler(ctx, request)
@@ -848,8 +848,8 @@ func (sh *strictHandler) GetChecklistItemBychecklistIdAndItemId(ctx *gin.Context
 	if err != nil {
 		ctx.Error(err)
 		ctx.Status(http.StatusInternalServerError)
-	} else if validResponse, ok := response.(GetChecklistItemBychecklistIdAndItemIdResponseObject); ok {
-		if err := validResponse.VisitGetChecklistItemBychecklistIdAndItemIdResponse(ctx.Writer); err != nil {
+	} else if validResponse, ok := response.(GetChecklistItemResponseObject); ok {
+		if err := validResponse.VisitGetChecklistItemResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
 	} else if response != nil {
@@ -857,14 +857,14 @@ func (sh *strictHandler) GetChecklistItemBychecklistIdAndItemId(ctx *gin.Context
 	}
 }
 
-// UpdateChecklistItemBychecklistIdAndItemId operation middleware
-func (sh *strictHandler) UpdateChecklistItemBychecklistIdAndItemId(ctx *gin.Context, checklistId uint, itemId uint) {
-	var request UpdateChecklistItemBychecklistIdAndItemIdRequestObject
+// UpdateChecklistItem operation middleware
+func (sh *strictHandler) UpdateChecklistItem(ctx *gin.Context, checklistId uint, itemId uint) {
+	var request UpdateChecklistItemRequestObject
 
 	request.ChecklistId = checklistId
 	request.ItemId = itemId
 
-	var body UpdateChecklistItemBychecklistIdAndItemIdJSONRequestBody
+	var body UpdateChecklistItemJSONRequestBody
 	if err := ctx.ShouldBindJSON(&body); err != nil {
 		ctx.Status(http.StatusBadRequest)
 		ctx.Error(err)
@@ -873,10 +873,10 @@ func (sh *strictHandler) UpdateChecklistItemBychecklistIdAndItemId(ctx *gin.Cont
 	request.Body = &body
 
 	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.UpdateChecklistItemBychecklistIdAndItemId(ctx, request.(UpdateChecklistItemBychecklistIdAndItemIdRequestObject))
+		return sh.ssi.UpdateChecklistItem(ctx, request.(UpdateChecklistItemRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "UpdateChecklistItemBychecklistIdAndItemId")
+		handler = middleware(handler, "UpdateChecklistItem")
 	}
 
 	response, err := handler(ctx, request)
@@ -884,8 +884,8 @@ func (sh *strictHandler) UpdateChecklistItemBychecklistIdAndItemId(ctx *gin.Cont
 	if err != nil {
 		ctx.Error(err)
 		ctx.Status(http.StatusInternalServerError)
-	} else if validResponse, ok := response.(UpdateChecklistItemBychecklistIdAndItemIdResponseObject); ok {
-		if err := validResponse.VisitUpdateChecklistItemBychecklistIdAndItemIdResponse(ctx.Writer); err != nil {
+	} else if validResponse, ok := response.(UpdateChecklistItemResponseObject); ok {
+		if err := validResponse.VisitUpdateChecklistItemResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
 	} else if response != nil {
@@ -893,15 +893,15 @@ func (sh *strictHandler) UpdateChecklistItemBychecklistIdAndItemId(ctx *gin.Cont
 	}
 }
 
-// ChangeChecklistItemOrderNumber operation middleware
-func (sh *strictHandler) ChangeChecklistItemOrderNumber(ctx *gin.Context, checklistId uint, itemId uint, params ChangeChecklistItemOrderNumberParams) {
-	var request ChangeChecklistItemOrderNumberRequestObject
+// ChangeChecklistItemOrder operation middleware
+func (sh *strictHandler) ChangeChecklistItemOrder(ctx *gin.Context, checklistId uint, itemId uint, params ChangeChecklistItemOrderParams) {
+	var request ChangeChecklistItemOrderRequestObject
 
 	request.ChecklistId = checklistId
 	request.ItemId = itemId
 	request.Params = params
 
-	var body ChangeChecklistItemOrderNumberJSONRequestBody
+	var body ChangeChecklistItemOrderJSONRequestBody
 	if err := ctx.ShouldBindJSON(&body); err != nil {
 		ctx.Status(http.StatusBadRequest)
 		ctx.Error(err)
@@ -910,10 +910,10 @@ func (sh *strictHandler) ChangeChecklistItemOrderNumber(ctx *gin.Context, checkl
 	request.Body = &body
 
 	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.ChangeChecklistItemOrderNumber(ctx, request.(ChangeChecklistItemOrderNumberRequestObject))
+		return sh.ssi.ChangeChecklistItemOrder(ctx, request.(ChangeChecklistItemOrderRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "ChangeChecklistItemOrderNumber")
+		handler = middleware(handler, "ChangeChecklistItemOrder")
 	}
 
 	response, err := handler(ctx, request)
@@ -921,8 +921,8 @@ func (sh *strictHandler) ChangeChecklistItemOrderNumber(ctx *gin.Context, checkl
 	if err != nil {
 		ctx.Error(err)
 		ctx.Status(http.StatusInternalServerError)
-	} else if validResponse, ok := response.(ChangeChecklistItemOrderNumberResponseObject); ok {
-		if err := validResponse.VisitChangeChecklistItemOrderNumberResponse(ctx.Writer); err != nil {
+	} else if validResponse, ok := response.(ChangeChecklistItemOrderResponseObject); ok {
+		if err := validResponse.VisitChangeChecklistItemOrderResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
 	} else if response != nil {

--- a/openapi/api_v1.yaml
+++ b/openapi/api_v1.yaml
@@ -1,12 +1,15 @@
 openapi: 3.0.3
 info:
-  title: Checklist service v1
-  description: Checklist service v1
+  title: Checklist Service API
+  description: OpenAPI specification for the Checklist service.
   version: 1.0.0
 paths:
   /:
     get:
       summary: Health check
+      operationId: healthCheck
+      tags:
+        - health
       responses:
         '200':
           description: Server is healthy
@@ -20,8 +23,8 @@ paths:
                     example: ok
   /api/v1/checklists:
     get:
-      summary: Get all checklists
-      operationId: getAllChecklists
+      summary: List all checklists
+      operationId: listChecklists
       tags:
         - checklist
       responses:
@@ -78,8 +81,8 @@ paths:
                 $ref: '#/components/schemas/Error'
   /api/v1/checklists/{checklistId}:
     get:
-      summary: Get checklist by ID
-      operationId: getChecklistById
+      summary: Get a checklist
+      operationId: getChecklist
       tags:
         - checklist
       parameters:
@@ -119,8 +122,8 @@ paths:
                 $ref: '#/components/schemas/Error'
 
     put:
-      summary: Update checklist by ID
-      operationId: UpdateChecklistById
+      summary: Update a checklist
+      operationId: updateChecklist
       tags:
         - checklist
       parameters:
@@ -165,8 +168,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
     delete:
-      summary: Delete checklist by ID
-      operationId: DeleteChecklistById
+      summary: Delete a checklist
+      operationId: deleteChecklist
       tags:
         - checklist
       parameters:
@@ -200,8 +203,8 @@ paths:
                 $ref: '#/components/schemas/Error'
   /api/v1/checklists/{checklistId}/items:
     get:
-      summary: Get all checklist items by checklist ID
-      operationId: getAllChecklistItems
+      summary: List checklist items
+      operationId: listChecklistItems
       tags:
         - checklistItem
       parameters:
@@ -250,7 +253,7 @@ paths:
                 $ref: '#/components/schemas/Error'
 
     post:
-      summary: Create a new checklist item
+      summary: Create a checklist item
       operationId: createChecklistItem
       tags:
         - checklistItem
@@ -291,8 +294,8 @@ paths:
                 $ref: '#/components/schemas/Error'
   /api/v1/checklists/{checklistId}/items/{itemId}:
     get:
-      summary: Get checklist item by checklist id and item id
-      operationId: GetChecklistItemBychecklistIdAndItemId
+      summary: Get a checklist item
+      operationId: getChecklistItem
       tags:
         - checklistItem
       parameters:
@@ -334,8 +337,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
     delete:
-      summary: Delete checklist item by checklistId and checklistItemId
-      operationId: DeleteChecklistItemById
+      summary: Delete a checklist item
+      operationId: deleteChecklistItem
       tags:
         - checklistItem
       parameters:
@@ -377,8 +380,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
     put:
-      summary: Update checklist item by checklist id and item id
-      operationId: UpdateChecklistItemBychecklistIdAndItemId
+      summary: Update a checklist item
+      operationId: updateChecklistItem
       tags:
         - checklistItem
       parameters:
@@ -435,8 +438,8 @@ paths:
 
   /api/v1/checklists/{checklistId}/items/{itemId}/change-order:
     patch:
-      summary: Change checklist item order number
-      operationId: ChangeChecklistItemOrderNumber
+      summary: Change checklist item order
+      operationId: changeChecklistItemOrder
       tags:
         - checklistItem
       parameters:
@@ -518,7 +521,7 @@ paths:
 
   /api/v1/checklists/{checklistId}/items/{itemId}/rows:
     post:
-      summary: Create checklist item row
+      summary: Create a checklist item row
       operationId: createChecklistItemRow
       tags:
         - checklistItem
@@ -580,6 +583,9 @@ components:
     Error:
       type: object
       properties:
+        code:
+          type: integer
+          format: int32
         message:
           type: string
           nullable: false
@@ -603,10 +609,6 @@ components:
     UpdateChecklistItemRequest:
       type: object
       properties:
-        id:
-          x-go-type: uint
-          type: integer
-          nullable: false
         name:
           type: string
           nullable: false
@@ -638,7 +640,6 @@ components:
               - completed
               - id
       required:
-        - id
         - name
         - completed
         - rows
@@ -713,7 +714,7 @@ components:
     CreateChecklistItemRowRequest:
       allOf:
         - $ref: '#/components/schemas/CreateOrUpdateChecklistItemRowRequest'
-    ChecklistUpdateAndCreateRequest:
+    CreateChecklistRequest:
       type: object
       properties:
         name:
@@ -722,13 +723,6 @@ components:
           minLength: 1
       required:
         - name
-    CreateChecklistRequest:
-      allOf:
-        - $ref: '#/components/schemas/ChecklistUpdateAndCreateRequest'
-    UpdateChecklistRequest:
-      type: object
-      allOf:
-        - $ref: '#/components/schemas/ChecklistUpdateAndCreateRequest'
     ChecklistResponse:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- clarify OpenAPI title and add health check operation
- standardize operation IDs and streamline request models
- define explicit error codes and regenerate controllers

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/github.com/davecgh/go-spew/@v/v1.1.1.zip": Forbidden; cmd/app.go:14:28: undefined: deployment.Init)*

------
https://chatgpt.com/codex/tasks/task_e_6891a6f66be48323a5ea0ea66b65fdc8