### PR TITLE
Handle no-op updates in item reorder

### DIFF
--- a/internal/repository/query/change_order.go
+++ b/internal/repository/query/change_order.go
@@ -57,14 +57,15 @@ func (c *ChangeChecklistItemOrderQueryFunction) setMovableItemToNewPrevItem(tx p
 			"newPrevItemId": newPreviousItem,
 			"itemToMoveId":  c.checklistItemId,
 		})
-		if err != nil {
-			return false, err
-		} else if tag.RowsAffected() > 1 {
-			return false, errors.New("updateChecklistItemPreviousItemOrderLinkFn affected more than one row")
-		}
+                if err != nil {
+                        return false, err
+                } else if tag.RowsAffected() > 1 {
+                        return false, errors.New("updateChecklistItemPreviousItemOrderLinkFn affected more than one row")
+                }
 
-		return tag.RowsAffected() == 1, err
-	}
+                // treat no-op updates as success to avoid failing when the value is already set
+                return tag.RowsAffected() <= 1, err
+        }
 
 	ok, err := execSQLFN(updateNewPreviousNextItemLink)
 	if err != nil || !ok {
@@ -123,14 +124,15 @@ func (c *ChangeChecklistItemOrderQueryFunction) setMovableItemToNewNextItem(tx p
 			"newNextItemId": newNextItemId,
 			"itemToMoveId":  c.checklistItemId,
 		})
-		if err != nil {
-			return false, err
-		} else if tag.RowsAffected() > 1 {
-			return false, errors.New("updateChecklistItemPreviousItemOrderLinkFn affected more than one row")
-		}
+                if err != nil {
+                        return false, err
+                } else if tag.RowsAffected() > 1 {
+                        return false, errors.New("updateChecklistItemPreviousItemOrderLinkFn affected more than one row")
+                }
 
-		return tag.RowsAffected() == 1, err
-	}
+                // Updates may already have desired value; treat such cases as success
+                return tag.RowsAffected() <= 1, err
+        }
 
 	ok, err := execSQLFN(updateNewNextItemPreviousLink)
 	if err != nil || !ok {


### PR DESCRIPTION
## Summary
- avoid treating no-op link updates as failures when changing checklist item order

## Testing
- `go test ./...` *(fails: command hung, had to interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689737225ad083239c2860ca344b195e