### PR TITLE
Add Dependabot configuration for Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Summary
- configure Dependabot for Go modules

## Testing
- `go test ./internal/... -run . -v` *(fails: interface conversion panic)*

------
https://chatgpt.com/codex/tasks/task_e_68974325e540832396fc110f672386e2