### PR TITLE
Fix test mocks to handle nil error returns

### DIFF
--- a/internal/core/service/checklist_items_service_test.go
+++ b/internal/core/service/checklist_items_service_test.go
@@ -21,8 +21,12 @@ func (m *mockChecklistItemsRepository) SaveChecklistItem(checklistId uint, check
 }
 
 func (m *mockChecklistItemsRepository) SaveChecklistItemRow(checklistId uint, itemId uint, row domain.ChecklistItemRow) (domain.ChecklistItemRow, domain.Error) {
-	args := m.Called(checklistId, itemId, row)
-	return args.Get(0).(domain.ChecklistItemRow), args.Get(1).(domain.Error)
+    args := m.Called(checklistId, itemId, row)
+    var err domain.Error
+    if e, ok := args.Get(1).(domain.Error); ok {
+        err = e
+    }
+    return args.Get(0).(domain.ChecklistItemRow), err
 }
 
 func (m *mockChecklistItemsRepository) FindChecklistItemById(checklistId uint, id uint) (*domain.ChecklistItem, domain.Error) {

--- a/internal/server/v1/checklistItem/checklist_item_controller_impl_test.go
+++ b/internal/server/v1/checklistItem/checklist_item_controller_impl_test.go
@@ -25,8 +25,12 @@ func (m *mockChecklistItemsService) UpdateChecklistItem(checklistId uint, checkl
 }
 
 func (m *mockChecklistItemsService) SaveChecklistItemRow(checklistId uint, itemId uint, row domain.ChecklistItemRow) (domain.ChecklistItemRow, domain.Error) {
-	args := m.Called(checklistId, itemId, row)
-	return args.Get(0).(domain.ChecklistItemRow), args.Get(1).(domain.Error)
+    args := m.Called(checklistId, itemId, row)
+    var err domain.Error
+    if e, ok := args.Get(1).(domain.Error); ok {
+        err = e
+    }
+    return args.Get(0).(domain.ChecklistItemRow), err
 }
 
 func (m *mockChecklistItemsService) FindChecklistItemById(checklistId uint, id uint) (*domain.ChecklistItem, domain.Error) {


### PR DESCRIPTION
## Summary
- avoid panic in mock SaveChecklistItemRow when error return is nil
- fix controller test mock to safely handle nil error

## Testing
- `go test ./internal/core/service -run TestChecklistItemsService_SaveChecklistItemRow -count=1 -v`
- `go test ./internal/server/v1/checklistItem -run TestChecklistItemController_CreateChecklistItemRow -count=1 -v`
- `go test ./internal/... -count=1`
- `go test ./... -count=1` *(fails: cmd/app.go:14:28: undefined: deployment.Init)*

------
https://chatgpt.com/codex/tasks/task_e_6897450117cc8323957e604aa4139317