### PR TITLE
Replace go.uber config with viper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,16 +5,16 @@ go 1.24.3
 tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
 
 require (
-	github.com/gin-gonic/gin v1.10.1
-	github.com/google/wire v0.6.0
-	github.com/jackc/pgx/v5 v5.7.5
-	github.com/oapi-codegen/gin-middleware v1.0.2
-	github.com/oapi-codegen/runtime v1.1.2
-	github.com/pkg/errors v0.9.1
-	github.com/raunlo/pgx-with-automapper v1.0.6
-	github.com/rendis/structsconv v1.0.0
-	github.com/stretchr/testify v1.10.0
-	go.uber.org/config v1.4.0
+        github.com/gin-gonic/gin v1.10.1
+        github.com/google/wire v0.6.0
+        github.com/jackc/pgx/v5 v5.7.5
+        github.com/oapi-codegen/gin-middleware v1.0.2
+        github.com/oapi-codegen/runtime v1.1.2
+        github.com/pkg/errors v0.9.1
+        github.com/raunlo/pgx-with-automapper v1.0.6
+        github.com/rendis/structsconv v1.0.0
+        github.com/spf13/viper v1.18.2
+        github.com/stretchr/testify v1.10.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -277,8 +277,6 @@ go.opentelemetry.io/otel/metric v1.35.0/go.mod h1:nKVFgxBZ2fReX6IlyW28MgZojkoAkJ
 go.opentelemetry.io/otel/trace v1.35.0 h1:dPpEfJu1sDIqruz7BHFG3c7528f6ddfSWfFDVt/xgMs=
 go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
-go.uber.org/config v1.4.0 h1:upnMPpMm6WlbZtXoasNkK4f0FhxwS+W4Iqz5oNznehQ=
-go.uber.org/config v1.4.0/go.mod h1:aCyrMHmUAc/s2h9sv1koP84M9ZF/4K+g2oleyESO/Ig=
 go.uber.org/multierr v1.4.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=


### PR DESCRIPTION
## Summary
- use Viper to load application configuration instead of go.uber.org/config
- implement custom environment variable expansion with defaults

## Testing
- `go mod tidy` *(fails: github.com/spf13/viper@v1.18.2: Get "https://proxy.golang.org/github.com/spf13/viper/@v/v1.18.2.mod": Forbidden)*
- `go test ./...` *(fails: missing go.sum entry for module providing package github.com/spf13/viper)*

------
https://chatgpt.com/codex/tasks/task_e_6897cbe19dac8323aa3835fb4e93d014